### PR TITLE
fix variable type declarations

### DIFF
--- a/ext/soundx/soundx.c
+++ b/ext/soundx/soundx.c
@@ -20,7 +20,7 @@ r                      => 6
  Pre-computed mapping of a-z to the above
  table.
 */
-static const char mapping[128] = {
+static const unsigned char mapping[128] = {
 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE,
 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE,
 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE, 0xFE,
@@ -46,7 +46,7 @@ static VALUE
 rb_soundx(int argc, VALUE* argv, VALUE self)
 {
   VALUE input;
-  const unsigned char* src;
+  unsigned char* src;
   int written = 0;
   size_t srclen;
   char *dest = malloc(5);
@@ -62,7 +62,7 @@ rb_soundx(int argc, VALUE* argv, VALUE self)
   }
 
   srclen = RSTRING_LEN(input);
-  src = (const unsigned char*) StringValueCStr(input);
+  src = (unsigned char *) StringValueCStr(input);
 
   dest[0] = toupper(src[0]);
 
@@ -83,8 +83,8 @@ rb_soundx(int argc, VALUE* argv, VALUE self)
 
     unsigned char current = tolower(src[i]);
 
-    char match = mapping[ current ];
-    if (0xFE == (int) match) {
+    unsigned char match = mapping[ current ];
+    if (0xFE == match) {
       continue;
     }
 


### PR DESCRIPTION
I think casting signed char `match` to int causes the comparison to 0xFE to fail because signed char only ranges from -128 to +127 and 0xFE == 254. For example,

```
[1] pry(main)> SoundX.encode("663ef7991a3a0bd3c8f99e2628298d28511287cbba3ecded22f53ca077c66f3d8b5dc8aac949a7400428fc9ca6e4f2039de1dbec1fffdbe88db1993b64bb72566c3e02298abc624dc021831959ea00a9519e6feeddbc249ca4a2b9d60476d31919633d3e")
=> "6\xFE1\xFE"
```

Changes:
* mapping is a const array of unsigned char
* declaring src as const is unnecessary
* match is unsigned char
* match doesn't need to be cast to int to compare with 0xFE

```
[1] pry(main)> SoundX.encode("663ef7991a3a0bd3c8f99e2628298d28511287cbba3ecded22f53ca077c66f3d8b5dc8aac949a7400428fc9ca6e4f2039de1dbec1fffdbe88db1993b64bb72566c3e02298abc624dc021831959ea00a9519e6feeddbc249ca4a2b9d60476d31919633d3e")
=> "6132"
```