### PR TITLE
Fix the first computed digit to be aware of the computed value of the destination's first character

### DIFF
--- a/ext/soundx/soundx.c
+++ b/ext/soundx/soundx.c
@@ -88,6 +88,14 @@ rb_soundx(int argc, VALUE* argv, VALUE self)
       continue;
     }
 
+    // The 2nd character must still respect
+    // the 'double code number' rule.
+    if (1 == i) {
+      if (match == mapping[tolower(src[0])]) {
+        continue;
+      }
+    }
+
     // Skip if previous character is the same
     if (dest[written] == match) {
       continue;

--- a/test/unit/soundx_test.rb
+++ b/test/unit/soundx_test.rb
@@ -67,4 +67,16 @@ describe 'SoundX' do
       assert_equal 'L200', SoundX.encode('Lukasiewicz')
     end
   end
+
+  describe ".encode given the ascii string 'Schwarzenegger'" do
+    it "returns the correct soundex" do
+      assert_equal 'S625', SoundX.encode('Schwarzenegger')
+    end
+  end
+
+  describe ".encode given the ascii string 'Shwarzenegger'" do
+    it "returns the correct soundex" do
+      assert_equal 'S625', SoundX.encode('Shwarzenegger')
+    end
+  end
 end


### PR DESCRIPTION
e.g. Schwarzenegger

```
s => 2
c => 2       <--- bug here. We should not place 2 in the first digit because 's' is also 2
h => skip
a => skip
r => 6
z => 2
e => skip
n => 5      --- We have 3 digits at this point and can ignore the rest

Correct output: S625
Before fix:  S262
```
The loop that maps digits to characters only respected the 'no double number' for digits 2 and 3.