### PR TITLE
Test against Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: xenial
 language: ruby
 rvm:
+  - 2.7
   - 2.6
   - 2.5
   - 2.4

--- a/test/unit/soundx_test.rb
+++ b/test/unit/soundx_test.rb
@@ -13,7 +13,7 @@ describe 'SoundX' do
   describe ".encode given a non-string" do
     it "returns a type error" do
       assert_raises TypeError do
-        SoundX.encode -1
+        SoundX.encode(-1)
       end
     end
   end


### PR DESCRIPTION
And fix  warning: 
```
../test/unit/soundx_test.rb:16: warning: ambiguous first argument; put parentheses or a space even after `-' operator
```